### PR TITLE
Fix splash screen display

### DIFF
--- a/src/demonlab_dashboard/main.py
+++ b/src/demonlab_dashboard/main.py
@@ -79,12 +79,6 @@ class GridLayoutTest(App):
             description="About",
             key_display="a",
         ),
-        Binding(
-            key="s",
-            action="splashscreen",
-            description="Splash",
-            key_display="s",
-        ),
     ]
 
     # Traffic light icons for user state
@@ -509,9 +503,11 @@ class GridLayoutTest(App):
             Button("SYNCTLop", variant="warning", id="but10"),
         )
 
-    async def on_mount(self):
-        # Show splash screen initially, fade-in effect clearly working
-        # await self.push_screen(SplashScreen())
+    async def on_mount(self) -> None:
+        """Display the splash screen briefly then start background tasks."""
+
+        # Show splash screen initially
+        await self.push_screen(SplashScreen())
 
         # Start the background notification listener
         self.notifications_task = asyncio.create_task(self.listen_notifications())
@@ -519,13 +515,13 @@ class GridLayoutTest(App):
         # Start system health updater task
         asyncio.create_task(self.update_health())
 
-        # @TODO: Resolve splash no show at startup.
+        # Hide the splash screen without blocking the UI
+        asyncio.create_task(self._auto_close_splash())
 
-        # Short delay clearly visible, then remove splash screen automatically
-
+    async def _auto_close_splash(self) -> None:
+        """Remove the splash screen after a brief delay."""
         await asyncio.sleep(3)
-
-    # await self.pop_screen()
+        await self.pop_screen()
 
     async def update_health(self):
         """Periodically update General System Health panel with query results explicitly."""
@@ -582,13 +578,6 @@ class GridLayoutTest(App):
         """Show screen action for 'a' key (about)."""
         self.push_screen(AboutScreen())
         return
-
-    def action_splashscreen(self) -> None:
-        """Show screen action for 's' key (splash)."""
-        # self.push_screen(SplashScreen())
-        pass
-        return
-
 
 # Main app entry point
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,46 @@
+import datetime
+import os
+import sys
+from unittest import mock
+
+# Ensure local src package is importable
+TEST_DIR = os.path.dirname(__file__)
+SRC_ROOT = os.path.join(TEST_DIR, "..", "src")
+sys.path.insert(0, SRC_ROOT)
+sys.path.insert(0, os.path.join(SRC_ROOT, "demonlab_dashboard"))
+
+from demonlab_dashboard.main import GridLayoutTest
+
+
+def test_query_db_next_datapoint():
+    app = GridLayoutTest()
+    fake_cursor = mock.Mock()
+    fake_cursor.fetchone.return_value = (
+        "Next Datapoint",
+        datetime.datetime(2025, 1, 1, 12, 0, 0),
+    )
+    fake_conn = mock.Mock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    with mock.patch("psycopg2.connect", return_value=fake_conn):
+        result = app.query_db_next_datapoint()
+
+    assert result == "Next Datapoint: 2025-01-01 12:00:00"
+    fake_cursor.execute.assert_called()
+    fake_cursor.close.assert_called_once()
+    fake_conn.close.assert_called_once()
+
+
+def test_query_db_next_datapoint_no_data():
+    app = GridLayoutTest()
+    fake_cursor = mock.Mock()
+    fake_cursor.fetchone.return_value = None
+    fake_conn = mock.Mock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    with mock.patch("psycopg2.connect", return_value=fake_conn):
+        result = app.query_db_next_datapoint()
+
+    assert result == "Next Datapoint: N/A"
+    fake_cursor.close.assert_called_once()
+    fake_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- handle splash screen asynchronously on startup
- remove unused splashscreen binding
- test missing datapoint case for `query_db_next_datapoint`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685910f4c9888327a61c6cc999e1e5df

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle splash screen asynchronously on startup and add tests for the next datapoint DB query.
> 
> - **App (`src/demonlab_dashboard/main.py`)**:
>   - Show `SplashScreen` on `on_mount` and auto-close via `_auto_close_splash` after a short delay; start `listen_notifications` and `update_health` concurrently.
>   - Remove `s` binding and `action_splashscreen`.
> - **Tests (`tests/test_main.py`)**:
>   - Add tests for `query_db_next_datapoint`, including no-data case, using mocked `psycopg2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47b336058de4b82529b1319ae5257a90547e89d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->